### PR TITLE
Partial fix for issue #4. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/.DS_Store
 build/
 
+CMakeLists.txt.user
+
 .vscode

--- a/Reader/vtkFitsReader/FitsReaderServerManager.xml
+++ b/Reader/vtkFitsReader/FitsReaderServerManager.xml
@@ -68,11 +68,18 @@
       <IntVectorProperty
         name="ScaleFactor"
         command="SetScaleFactor"
+        information_property="ScaleFactorInfo"
         number_of_elements="1"
         default_values="1">
         <Documentation>
           This property can be used to read only every inc-th pixel along the dimensions of the image.
         </Documentation>
+      </IntVectorProperty>
+      
+      <IntVectorProperty
+        command="GetScaleFactor"
+        information_only="1"
+        name="ScaleFactorInfo">
       </IntVectorProperty>
 
       <Hints>


### PR DESCRIPTION
Autoscale scalefactor cannot be read, but manual works as intended. Don't know why the auto doesn't work, Paraview dev suggestion ([here](https://stackoverflow.com/questions/75927400/how-to-set-a-paraview-server-plugin-property-server-side-to-later-retrieve-from)) didn't work. Might have misunderstood what they were trying to say, have asked for clarification.